### PR TITLE
added php 8.0 to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "php": "^5.3 || ^7.0"
+        "php": "^5.3 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9"


### PR DESCRIPTION
Hi dan-on,

I changed to composer requirements to also include php 8.0. I am running it on our dev server at the moment. All tests work on php 8.0. Since there is no CI, I added a screenshot as "proof".

![image](https://user-images.githubusercontent.com/16435930/103924298-1ea21080-5116-11eb-8884-559e41a61f94.png)

Thanks you for implementing this data structure. It is highly useful to my project.

Kind regards,

Ghlen